### PR TITLE
Fetch route

### DIFF
--- a/transit_simulation/route.py
+++ b/transit_simulation/route.py
@@ -1,0 +1,33 @@
+import requests
+
+def fetch_route(bus_route_id, direction, d_date, d_time):
+    '''
+    Args:
+        bus_route_id - identifier of a route
+        direction - Direction of the trip, possible values: 0, 1 or -1. -1 indicates that the direction is irrelevant, i.e. in case the route has trips only in one direction.
+        date - Departure date of the trip, format: YYYY-MM-DD
+        time - Departure time of the trip, format: seconds since midnight of the departure date
+    
+    Returns:
+        route - A list of points describing the shape of the route.
+    '''
+    api_url = 'https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql'
+    query = '''
+    {{
+        route: fuzzyTrip(route: "HSL:{}", direction: {}, date: "{}", time: {}) {{
+            geometry
+        }}
+    }}
+    '''.format(bus_route_id, direction, d_date, d_time)
+    request = requests.post(api_url, json={'query': query})
+    route = request.json()['data']['route']['geometry']
+    
+    return route
+
+if __name__ == "__main__":
+    route_id = 1071
+    direction = 1
+    d_date = "2020-04-29"
+    d_time = 16800
+    
+    pointlist = fetch_route(route_id, direction, d_date, d_time)


### PR DESCRIPTION
A simple function for fetching route geometry from HSL api. 

Inputs: route id, direction, and date and time of the departure (should be available in mqtt messages).
Returns: A list of coordinates.

Possible improvements:
- The format of the direction key is different in this and real-time api. Maybe a function for converting these keys so we can use either in general code.
- A function that processes the point list to e.g. linestring or whatever we want to use.
- Functions accessing real-time api could be extended so that those return the time and date for this function (@janpisl?). 